### PR TITLE
feat: ❇️ 키 저장소 객체의 Key 타입을 제너릭으로 추상화

### DIFF
--- a/Somniary/Common/KeyStoring.swift
+++ b/Somniary/Common/KeyStoring.swift
@@ -17,7 +17,8 @@ protocol KeyStoring {
     func clear(keys: [ValueKey])
 }
 
-extension KeyStoring where ValueKey: RawRepresentable, ValueKey.RawValue == String {
+// MARK: associatedtype 이 enum 타입인 경우를 가정
+extension KeyStoring where ValueKey: RawRepresentable, ValueKey.RawValue == String, ValueKey: CaseIterable, ValueKey.AllCases == [ValueKey] {
 
     func save<T: Codable>(_ value: T, for key: ValueKey) {
         let data = try? JSONEncoder().encode(value)
@@ -32,8 +33,13 @@ extension KeyStoring where ValueKey: RawRepresentable, ValueKey.RawValue == Stri
         return try? JSONDecoder().decode(T.self, from: data)
     }
 
+    /// 명시적 타입 지정을 통한 구조체 불러오기
+    func retrieve<T: Decodable>(type: T.Type, for key: ValueKey) -> T? {
+        return retrieve(for: key)
+    }
+
     /// 복수 키 삭제
-    func clear(keys: [ValueKey]) {
+    func clear(keys: [ValueKey] = ValueKey.allCases) {
         keys.forEach({ UserDefaults.standard.removeObject(forKey: $0.rawValue) })
     }
 

--- a/Somniary/Common/LocalStorage.swift
+++ b/Somniary/Common/LocalStorage.swift
@@ -7,12 +7,6 @@
 
 import Foundation
 
-final class LocalStorage: KeyStoring {
-    static let shared = LocalStorage()
-
-    enum ValueKey: String, CaseIterable {
-        // TODO: 로컬 저장소에 저장할 키 정의
-        case accessToken
-        case refreshToken
-    }
+final class LocalStorage<Key>: KeyStoring where Key: RawRepresentable, Key.RawValue == String, Key: CaseIterable, Key.AllCases == [Key] {
+    typealias ValueKey = Key
 }


### PR DESCRIPTION
### 개선 내용
- 제너릭 Key 타입을 추가해 저장소 객체 생성 시, 원하는 제너릭 타입을 명시하여 사용할 수 있도록 개선

```Swift
enum User: String, CaseIterable {
     case id
     case password
}

let storage = KeychainStorage<User>()
let password: String = // ...

// store
storage.save(password, for: .password)

// retrieve
let pw: String? = storage.retrieve(for: .password)
let pw2 = storage.retrieve(type: String.self, for: .password)
```