### PR TITLE
fix: 🐛 API Client 응답 오류 수정

### DIFF
--- a/Somniary/Network/Interfaces/Endpoint.swift
+++ b/Somniary/Network/Interfaces/Endpoint.swift
@@ -15,7 +15,9 @@ enum RequestDataType {
     case entity(data: Encodable, encoder: ParameterEncoder)
 }
 
+/// 어디로, 어떻게, 무엇을 보낼지 정의
 protocol Endpoint: URLRequestConvertible {
+
     var baseURL: URL { get }
     var path: String { get }
     var method: HTTPMethod { get }
@@ -25,6 +27,7 @@ protocol Endpoint: URLRequestConvertible {
 }
 
 extension Endpoint {
+
     var headers: HTTPHeaders? { nil }
     var queryItems: [URLQueryItem]? { nil }
     var payload: RequestDataType? { .plain }
@@ -33,7 +36,10 @@ extension Endpoint {
         let url = self.baseURL.appending(path: self.path, queryItems: self.queryItems ?? [])
         var request = try URLRequest(url: url, method: self.method, headers: self.headers)
         request.headers.update(.contentType("application/json"))
+        return try buildPayload(request)
+    }
 
+    func buildPayload(_ request: URLRequest) throws -> URLRequest {
         if case let .jsonObject(data, encoder) = payload {
             let requestWithPayload = try encoder.encode(request, with: data)
             return requestWithPayload
@@ -46,11 +52,4 @@ extension Endpoint {
 
         return request
     }
-}
-
-/// type erasure for Encodable body
-struct AnyEncodable: Encodable {
-    private let _encode: (Encoder) throws -> Void
-    init(_ wrapped: Encodable) { _encode = wrapped.encode }
-    func encode(to encoder: Encoder) throws { try _encode(encoder) }
 }

--- a/Somniary/Network/Interfaces/SomniaryEndpoint.swift
+++ b/Somniary/Network/Interfaces/SomniaryEndpoint.swift
@@ -6,12 +6,25 @@
 //
 
 import Foundation
+import Alamofire
 
 protocol SomniaryEndpoint: Endpoint {}
 
+/// 도메인 공통 로직 추가
 extension SomniaryEndpoint {
-
+    /// DIP 트레이드 오프
     var baseURL: URL {
-        return URL(string: "https://api.somniary.io")!
+        guard let url = URL(string: AppInfo.shared.domainServiceURL) else {
+            fatalError("AppInfo.shared.domainServiceURL is nil")
+        }
+
+        return url
+    }
+
+    /// DIP 트레이드 오프
+    var headers: HTTPHeaders {
+        return HTTPHeaders([
+            "apiKey": AppInfo.shared.domainClientKey
+        ])
     }
 }


### PR DESCRIPTION
### 작업 내용
- API 400, 500 에러 시 catch 문으로 빠지지 않는 오류 수정
- 불필요한 코드 제거
- 백엔드 URL, API Key 주입
  - supbase client key 로 외부에 노출되어도 문제 없음